### PR TITLE
Improves UI of the offer detail

### DIFF
--- a/EmpleoDotNet/Views/JobOpportunity/Detail.cshtml
+++ b/EmpleoDotNet/Views/JobOpportunity/Detail.cshtml
@@ -14,21 +14,20 @@
         <div class="row">
             <div class="col-sm-12 text-center">
                 <h1>@Model.Title</h1>
-                <h4>
+
                     @if (Model.JobOpportunityLocation == null)
                     {
-                        <span><i class="fa fa-map-marker"></i>N/A</span>
+                        <h4><span><i class="fa fa-map-marker"></i>N/A</span></h4>
                     }
                     else
                     {
-                        <span><i class="fa fa-map-marker"></i>@Model.JobOpportunityLocation.Name</span>
+                        <h4><span><i class="fa fa-map-marker"></i>@Model.JobOpportunityLocation.Name</span></h4>
                     }
-                    <span><i class="fa fa-cog"></i>@Model.Category.ToEnumDescription()</span>
+                    <h4><span><i class="fa fa-cog"></i>@Model.Category.ToEnumDescription()</span></h4>
                     @if (Model.IsRemote)
                     {
-                        <span><i class="fa fa-globe"></i>Remoto</span>
+                        <h4><span><i class="fa fa-globe"></i>Remoto</span></h4>
                     }
-                </h4>
                 <h5 class="text-center"><i class="fa fa-calendar"></i> @Model.Created.ToString("dd MMMM yyyy")</h5>
             </div>
         </div>


### PR DESCRIPTION
- Allows `JobOpportunityLocation` and `Category` to be displayed as full width `<h5>`s.

This change makes:

![before](https://www.evernote.com/shard/s81/sh/30fb502f-1311-4d2b-9def-69cc566f08d7/77d73ad5c5d4ae0f/res/a17078fa-3efe-4437-a475-afa6260ea97f/skitch.png?resizeSmall&width=832)

To:

![after](https://www.evernote.com/shard/s81/sh/2922ab85-e57c-4f32-8921-a4d9fa0f8804/82947c79f20ee582/res/3404bb5f-16cd-4600-8295-287c0974f74b/skitch.png?resizeSmall&width=832)
